### PR TITLE
Rewrite tests with new Quality improvement, closes #85

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -17,15 +17,15 @@ dependencies {
     implementation "org.dmfs:semver:0.2.0"
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.2.0.202206071550-r'
     implementation 'org.dmfs:srcless-annotations:0.3.0'
-    implementation "org.dmfs:jems2:2.18.0"
+    implementation "org.dmfs:jems2:2.19.0"
     annotationProcessor 'org.dmfs:srcless-processors:0.3.0'
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
-    testImplementation "org.dmfs:jems2-testing:2.18.0"
+    testImplementation "org.dmfs:jems2-testing:2.19.0"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.dmfs:jems2-confidence:2.18.0"
+    testImplementation "org.dmfs:jems2-confidence:2.19.0"
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.saynotobugs:confidence-core:0.22.3"
     testImplementation "org.saynotobugs:confidence-incubator:0.22.3"

--- a/gradle-plugin/src/test/java/org/dmfs/gradle/gver/tasks/TagReleaseTaskTest.java
+++ b/gradle-plugin/src/test/java/org/dmfs/gradle/gver/tasks/TagReleaseTaskTest.java
@@ -5,19 +5,24 @@ import org.dmfs.gradle.gver.utils.TestProject;
 import org.dmfs.gver.dsl.Strategy;
 import org.dmfs.gver.git.changetypefacories.condition.CommitMessage;
 import org.dmfs.gver.git.predicates.Contains;
+import org.dmfs.jems2.FragileFunction;
 import org.dmfs.jems2.iterable.Mapped;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Ref;
+import org.gradle.api.Project;
 import org.saynotobugs.confidence.description.Text;
 import org.saynotobugs.confidence.junit5.engine.Assertion;
 import org.saynotobugs.confidence.junit5.engine.Confidence;
+import org.saynotobugs.confidence.junit5.engine.assertion.WithResource;
 import org.saynotobugs.confidence.junit5.engine.resource.TempDir;
+
+import java.io.File;
 
 import static org.dmfs.gver.git.ChangeType.*;
 import static org.dmfs.jems2.confidence.Jems2.procedureThatAffects;
 import static org.eclipse.jgit.lib.Constants.R_TAGS;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.saynotobugs.confidence.junit5.engine.ConfidenceEngine.*;
+import static org.saynotobugs.confidence.junit5.engine.ConfidenceEngine.assertionThat;
+import static org.saynotobugs.confidence.junit5.engine.ConfidenceEngine.withResources;
 import static org.saynotobugs.confidence.quality.Core.*;
 
 
@@ -29,14 +34,17 @@ class TagReleaseTaskTest
             new TempDir(),
             new Repository(getClass().getClassLoader().getResource("0.0.2-alpha.1.bundle"), "main"),
 
-            (tempDir, repo) -> withResource(
-                new TestProject(tempDir,
+
+            (tempDir, repo) -> withResources("temporary user home dir and project",
+                new TempDir(),
+                (FragileFunction<File, WithResource.Resource<Project>, Exception>) new TestProject(tempDir,
                     new Strategy(
                         MAJOR.when(new CommitMessage(new Contains("#major"))),
                         MINOR.when(new CommitMessage(new Contains("#minor"))),
                         PATCH.when(new CommitMessage(new Contains("#patch"))),
                         UNKNOWN.when(((repository1, commit, branches) -> true)))),
-                project -> assertionThat(
+
+                (gradleDir, project) -> assertionThat(
                     repository -> ((TagReleaseTask) project.getTasks().getByName("gitTagRelease")).perform(),
                     is(procedureThatAffects(
                         new Text("alters repository"),
@@ -50,30 +58,24 @@ class TagReleaseTaskTest
             new TempDir(),
             new Repository(getClass().getClassLoader().getResource("0.2.0-alpha.1.feature.bundle"), "feature"),
 
-            (tempDir, repo) -> withResource(new TestProject(tempDir,
+
+            (tempDir, repo) -> withResources("temporary user home dir and project",
+                new TempDir(),
+                (FragileFunction<File, WithResource.Resource<Project>, Exception>) new TestProject(tempDir,
                     new Strategy(
                         MAJOR.when(new CommitMessage(new Contains("#major"))),
                         MINOR.when(new CommitMessage(new Contains("#minor"))),
                         PATCH.when(new CommitMessage(new Contains("#patch"))),
                         UNKNOWN.when(((repository1, commit, branches) -> true)))),
-                project -> assertionThat(
-                    repository -> {
-                        try
-                        {
-                            ((TagReleaseTask) project.getTasks().getByName("gitTagRelease")).perform();
-                            fail("did not throw");
-                        }
-                        catch (Exception e)
-                        {
-                            // ignore the exception until we have a Confidence Quality to test for it
-                            // for now we just ensure no tag has been added
-                        }
-                    },
+
+                (gradleDir, project) -> assertionThat(
+                    repository -> ((TagReleaseTask) project.getTasks().getByName("gitTagRelease")).perform(),
                     is(procedureThatAffects(
-                        new Text("alters repository"),
+                        new Text("does not generate new tags"),
                         () -> repo,
                         soIt(has(repository -> new Mapped<>(Ref::getName, new Git(repository).tagList().call()),
-                            iteratesInAnyOrder(R_TAGS + "0.0.1", R_TAGS + "0.1.0"))))))));
+                            iteratesInAnyOrder(R_TAGS + "0.0.1", R_TAGS + "0.1.0"))),
+                        when(throwing(IllegalStateException.class)))))));
 
 
     Assertion gitTagRelease_skips_existing_tag =
@@ -81,14 +83,17 @@ class TagReleaseTaskTest
             new TempDir(),
             new Repository(getClass().getClassLoader().getResource("0.2.0-trivial-change.bundle"), "main"),
 
-            (tempDir, repo) -> withResource(new TestProject(tempDir,
+            (tempDir, repo) -> withResources("temporary user home dir and project",
+                new TempDir(),
+                (FragileFunction<File, WithResource.Resource<Project>, Exception>) new TestProject(tempDir,
                     new Strategy(
                         NONE.when(new CommitMessage(new Contains("#none"))),
                         MAJOR.when(new CommitMessage(new Contains("#major"))),
                         MINOR.when(new CommitMessage(new Contains("#minor"))),
                         PATCH.when(new CommitMessage(new Contains("#patch"))),
                         UNKNOWN.when(((repository1, commit, branches) -> true)))),
-                project -> assertionThat(
+
+                (gradleDir, project) -> assertionThat(
                     repository -> ((TagReleaseTask) project.getTasks().getByName("gitTagRelease")).perform(),
                     is(procedureThatAffects(
                         new Text("alters repository"),

--- a/gradle-plugin/src/test/java/org/dmfs/gradle/gver/tasks/TagTaskTest.java
+++ b/gradle-plugin/src/test/java/org/dmfs/gradle/gver/tasks/TagTaskTest.java
@@ -1,80 +1,57 @@
 package org.dmfs.gradle.gver.tasks;
 
-import org.dmfs.gver.dsl.GitVersionConfig;
+import org.dmfs.gradle.gver.utils.Repository;
+import org.dmfs.gradle.gver.utils.TestProject;
 import org.dmfs.gver.dsl.Strategy;
+import org.dmfs.gver.git.Suffixes;
 import org.dmfs.gver.git.changetypefacories.condition.CommitMessage;
 import org.dmfs.gver.git.predicates.Contains;
-import org.dmfs.jems2.Procedure;
-import org.dmfs.jems2.function.Unchecked;
+import org.dmfs.jems2.FragileFunction;
 import org.dmfs.jems2.iterable.Mapped;
 import org.dmfs.jems2.optional.Present;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.lib.Repository;
 import org.gradle.api.Project;
-import org.gradle.testfixtures.ProjectBuilder;
-import org.junit.jupiter.api.Test;
+import org.saynotobugs.confidence.description.Text;
+import org.saynotobugs.confidence.junit5.engine.Assertion;
+import org.saynotobugs.confidence.junit5.engine.Confidence;
+import org.saynotobugs.confidence.junit5.engine.assertion.WithResource;
+import org.saynotobugs.confidence.junit5.engine.resource.TempDir;
 
-import static java.util.Arrays.asList;
-import static org.dmfs.gradle.gver.utils.Matchers.given;
-import static org.dmfs.gradle.gver.utils.Tools.withRepository;
-import static org.dmfs.gradle.gver.utils.Tools.withTempFolder;
+import java.io.File;
+
 import static org.dmfs.gver.git.ChangeType.*;
-import static org.dmfs.jems2.hamcrest.matchers.LambdaMatcher.having;
-import static org.dmfs.jems2.hamcrest.matchers.procedure.ProcedureMatcher.processes;
+import static org.dmfs.jems2.confidence.Jems2.procedureThatAffects;
 import static org.eclipse.jgit.lib.Constants.R_TAGS;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.saynotobugs.confidence.junit5.engine.ConfidenceEngine.assertionThat;
+import static org.saynotobugs.confidence.junit5.engine.ConfidenceEngine.withResources;
+import static org.saynotobugs.confidence.quality.Core.*;
 
 
+@Confidence
 class TagTaskTest
 {
-    @Test
-    void test()
-    {
-        assertThat((Procedure<Project>) project -> {
-                try
-                {
-                    ((TagTask) project.getTasks().getByName("gitTag")).perform();
-                }
-                catch (Exception e)
-                {
-                    throw new AssertionError("Unexpected Exception", e);
-                }
-            },
-            withTempFolder(
-                userHome ->
-                    withTempFolder(tempDir ->
-                        withRepository(getClass().getClassLoader().getResource("0.0.2-alpha.1.bundle"),
-                            tempDir,
-                            "main",
-                            repository ->
-                                given(
-                                    () ->
-                                    {
-                                        Project p = ProjectBuilder.builder()
-                                            .withProjectDir(tempDir)
-                                            .withGradleUserHomeDir(userHome)
-                                            .build();
-                                        p.getPluginManager().apply("org.dmfs.gver");
-                                        ((GitVersionConfig) p.getExtensions().getByName("gver")).mChangeTypeStrategy = new Strategy();
-                                        ((GitVersionConfig) p.getExtensions().getByName("gver")).mChangeTypeStrategy.mChangeTypeStrategies.addAll(
-                                            asList(
-                                                MAJOR.when(new CommitMessage(new Contains("#major"))),
-                                                MINOR.when(new CommitMessage(new Contains("#minor"))),
-                                                PATCH.when(new CommitMessage(new Contains("#patch"))),
-                                                UNKNOWN.when(((repository1, commit, branches) -> true))));
-                                        ((GitVersionConfig) p.getExtensions().getByName("gver")).mSuffixes.mSuffixes.replaceAll(
-                                            any -> (repository12, commit, branch) -> new Present<>("-SNAPSHOT"));
-                                        return p;
-                                    },
-                                    project -> having(
-                                        "p",
-                                        proc -> repo -> proc.process(project),
-                                        processes(() -> repository,
-                                            having(new Unchecked<Repository, Iterable<String>, Exception>(
-                                                    r -> new Mapped<>(Ref::getName, new Git(r).tagList().call())),
-                                                containsInAnyOrder(R_TAGS + "0.0.1", R_TAGS + "0.0.2-alpha.1-SNAPSHOT"))
-                                        )))))));
-    }
+
+    Assertion gitTagRelease_adds_tag_for_current_version =
+        withResources("with temporary directory and git repository",
+            new TempDir(),
+            new Repository(getClass().getClassLoader().getResource("0.0.2-alpha.1.bundle"), "main"),
+
+            // we use a separate gradle home dir to make this test pass
+            (tempDir, repo) -> withResources("temporary user home dir and project",
+                new TempDir(),
+                (FragileFunction<File, WithResource.Resource<Project>, Exception>) new TestProject(tempDir,
+                    new Strategy(
+                        MAJOR.when(new CommitMessage(new Contains("#major"))),
+                        MINOR.when(new CommitMessage(new Contains("#minor"))),
+                        PATCH.when(new CommitMessage(new Contains("#patch"))),
+                        UNKNOWN.when(((repository1, commit, branches) -> true))),
+                    new Suffixes((repository12, commit, branch) -> new Present<>("-SNAPSHOT"))),
+
+                (userHome, project) -> assertionThat(repository -> ((TagTask) project.getTasks().getByName("gitTag")).perform(),
+                    is(procedureThatAffects(
+                        new Text("alters repository"),
+                        () -> repo,
+                        soIt(has(repository -> new Mapped<>(Ref::getName, new Git(repository).tagList().call()),
+                            iteratesInAnyOrder(R_TAGS + "0.0.1", R_TAGS + "0.0.2-alpha.1-SNAPSHOT"))))))));
 }

--- a/gradle-plugin/src/test/java/org/dmfs/gradle/gver/utils/TestProject.java
+++ b/gradle-plugin/src/test/java/org/dmfs/gradle/gver/utils/TestProject.java
@@ -2,7 +2,9 @@ package org.dmfs.gradle.gver.utils;
 
 import org.dmfs.gver.dsl.GitVersionConfig;
 import org.dmfs.gver.dsl.Strategy;
+import org.dmfs.gver.git.Suffixes;
 import org.dmfs.jems2.Fragile;
+import org.dmfs.jems2.FragileFunction;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.saynotobugs.confidence.junit5.engine.assertion.WithResource;
@@ -10,24 +12,43 @@ import org.saynotobugs.confidence.junit5.engine.assertion.WithResource;
 import java.io.File;
 
 
-public final class TestProject implements Fragile<WithResource.Resource<Project>, Exception>
+public final class TestProject implements Fragile<WithResource.Resource<Project>, Exception>,
+    FragileFunction<File, WithResource.Resource<Project>, Exception>
 {
     private final File mProjectDir;
     private final Strategy mStrategy;
+    private final Suffixes mSuffixes;
 
     public TestProject(File projectDir, Strategy strategy)
     {
+        this(projectDir, strategy, new Suffixes());
+    }
+
+    public TestProject(File projectDir, Strategy strategy, Suffixes suffixes)
+    {
         mProjectDir = projectDir;
         mStrategy = strategy;
+        mSuffixes = suffixes;
     }
 
 
     @Override
     public WithResource.Resource<Project> value() throws Exception
     {
-        Project project = ProjectBuilder.builder().withProjectDir(mProjectDir).build();
+        return value(mProjectDir);
+    }
+
+    @Override
+    public WithResource.Resource<Project> value(File file) throws Exception
+    {
+        Project project = ProjectBuilder.builder()
+            .withProjectDir(mProjectDir)
+            .withGradleUserHomeDir(file)
+            .build();
         project.getPluginManager().apply("org.dmfs.gver");
         ((GitVersionConfig) project.getExtensions().getByName("gver")).mChangeTypeStrategy = mStrategy;
+        ((GitVersionConfig) project.getExtensions().getByName("gver")).mSuffixes = mSuffixes;
+
 
         return new WithResource.Resource<Project>()
         {
@@ -46,5 +67,4 @@ public final class TestProject implements Fragile<WithResource.Resource<Project>
 
         };
     }
-
 }

--- a/gver-dsl/build.gradle
+++ b/gver-dsl/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation "org.dmfs:rfc5545-datetime:0.3"
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.2.0.202206071550-r'
     implementation 'org.dmfs:srcless-annotations:0.3.0'
-    implementation "org.dmfs:jems2:2.18.0"
+    implementation "org.dmfs:jems2:2.19.0"
 
     testAnnotationProcessor 'org.dmfs:srcless-processors:0.3.0'
 
@@ -38,8 +38,8 @@ dependencies {
     testImplementation "org.dmfs:semver-confidence:0.2.0"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
-    testImplementation "org.dmfs:jems2-testing:2.18.0"
-    testImplementation "org.dmfs:jems2-confidence:2.18.0"
+    testImplementation "org.dmfs:jems2-testing:2.19.0"
+    testImplementation "org.dmfs:jems2-confidence:2.19.0"
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.saynotobugs:confidence-core:0.22.3"
     testImplementation "org.saynotobugs:confidence-incubator:0.22.3"

--- a/gver-dsl/src/main/java/org/dmfs/gver/git/Suffixes.java
+++ b/gver-dsl/src/main/java/org/dmfs/gver/git/Suffixes.java
@@ -1,14 +1,17 @@
 package org.dmfs.gver.git;
 
+import groovy.lang.Closure;
 import org.dmfs.gver.dsl.Conditions;
 import org.dmfs.gver.dsl.SuffixPattern;
 import org.dmfs.gver.dsl.SuffixStrategy;
 import org.dmfs.gver.git.predicates.IsDirty;
 import org.dmfs.jems2.Optional;
 import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.jems2.optional.Absent;
 import org.dmfs.jems2.optional.FirstPresent;
 import org.dmfs.jems2.optional.Present;
+import org.dmfs.jems2.single.Collected;
 import org.dmfs.rfc5545.DateTime;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -16,10 +19,6 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-
-import groovy.lang.Closure;
-
-import static org.codehaus.groovy.runtime.InvokerHelper.asList;
 
 
 public final class Suffixes
@@ -31,7 +30,25 @@ public final class Suffixes
                 : new DateTime(commit.getCommitTime() * 1000L)) // clean repo gets the last commit date
             + "-SNAPSHOT");
 
-    public final List<SuffixStrategy> mSuffixes = new ArrayList<>(asList(DEFAULT_STRATEGY.get()));
+    public final List<SuffixStrategy> mSuffixes;
+
+    public Suffixes()
+    {
+        this(DEFAULT_STRATEGY.get());
+    }
+
+
+    public Suffixes(SuffixStrategy... suffixStrategies)
+    {
+        this(new Collected<>(ArrayList::new, new Seq<>(suffixStrategies)).value());
+    }
+
+
+    public Suffixes(List<SuffixStrategy> suffixStrategies)
+    {
+        mSuffixes = suffixStrategies;
+    }
+
 
     /**
      * {@code "\u0000"} is not a valid suffix character. We use it to represent the default suffix.


### PR DESCRIPTION
This uses the improved `procedureThatAfects` quality to get rid of the imperative exceptino handling.