### PR TITLE
Rework task descriptions and groups

### DIFF
--- a/gradle-plugin/src/main/java/org/dmfs/gradle/gver/tasks/TagReleaseTask.java
+++ b/gradle-plugin/src/main/java/org/dmfs/gradle/gver/tasks/TagReleaseTask.java
@@ -26,6 +26,12 @@ import static org.eclipse.jgit.lib.Constants.R_TAGS;
  */
 public class TagReleaseTask extends DefaultTask
 {
+    public TagReleaseTask()
+    {
+        setGroup("gver");
+        setDescription("Tags the HEAD commit with a new release version.");
+    }
+
     @TaskAction
     public void perform() throws IOException, GitAPIException
     {

--- a/gradle-plugin/src/main/java/org/dmfs/gradle/gver/tasks/TagTask.java
+++ b/gradle-plugin/src/main/java/org/dmfs/gradle/gver/tasks/TagTask.java
@@ -17,6 +17,12 @@ import java.io.IOException;
  */
 public class TagTask extends DefaultTask
 {
+    public TagTask()
+    {
+        setGroup("gver");
+        setDescription("Tags the HEAD commit with the current project version.");
+    }
+
     @TaskAction
     public void perform() throws IOException, GitAPIException
     {

--- a/gradle-plugin/src/main/java/org/dmfs/gradle/gver/tasks/VersionTask.java
+++ b/gradle-plugin/src/main/java/org/dmfs/gradle/gver/tasks/VersionTask.java
@@ -10,14 +10,11 @@ import org.gradle.api.tasks.TaskAction;
  */
 public class VersionTask extends DefaultTask
 {
-
     public VersionTask()
     {
-        // TODO: is there a better place/way to set these?
         setGroup("gver");
-        setDescription("show the current project version");
+        setDescription("Shows the current project version.");
     }
-
 
     @TaskAction
     public void perform()


### PR DESCRIPTION
This makes all tasks get listed by `gradle tasks`.