### PR TITLE
Fix publishing, fixes #102

### DIFF
--- a/gver-dsl/publish.gradle
+++ b/gver-dsl/publish.gradle
@@ -4,12 +4,12 @@ if (project.hasProperty('SONATYPE_USERNAME') && project.hasProperty('SONATYPE_PA
     apply plugin: 'signing'
 
     task javadocJar(type: Jar, dependsOn: javadoc) {
-        classifier = 'javadoc'
+        archiveClassifier = 'javadoc'
         from javadoc.destinationDir
     }
 
     task sourceJar(type: Jar) {
-        classifier "sources"
+        archiveClassifier = "sources"
         from sourceSets.main.allJava
     }
 


### PR DESCRIPTION
The name of the classifier property has changed in Gradle 8, see https://stackoverflow.com/questions/75660848/could-not-set-unknown-property-classifier-for-task-idl-parsersourcejar-of